### PR TITLE
Doubutsuのに機能追加とBoardの修正

### DIFF
--- a/Board.pde
+++ b/Board.pde
@@ -16,7 +16,7 @@ class Board {
     mArea[1].draw();
     iArea.draw();
   }
-}
+
 void select(int x, int y){
     AbstractKoma koma = komaList.getSelectedKoma();
     if(koma==null){
@@ -25,3 +25,4 @@ void select(int x, int y){
       koma.kStat.selected=false;
     }
   }
+ }

--- a/Doubutsu.pde
+++ b/Doubutsu.pde
@@ -1,14 +1,22 @@
 final int SQUARESIZE = 100;
 Board board;
 KomaList komaList;
+GameStatus gs;
 
 void setup() {
   surface.setSize(6*SQUARESIZE, 4*SQUARESIZE);
   board = new Board();
   komaList = new KomaList();
+  gs = new GameStatus();
 }
 
 void draw() {
   board.draw();
   komaList.draw();
+}
+
+void mouseReleased() {
+  int x = mouseX/SQUARESIZE;
+  int y = mouseY/SQUARESIZE;
+  board.select(x, y);
 }


### PR DESCRIPTION
実施内容
Boardクラスにselect()メソッドを追加する

select()メソッドでは，KomaListクラスのインスタンスkomaListのgetSelectedKoma()メソッドを利用して，既に選択されているコマ（ある場合）を取得する．選択済みのコマがない場合は座標(x,y)に存在するそのターン(Left/Right)に属するコマを選択するため，komaListのselect(x,y)を呼び出す．ある場合は選択済みのコマの選択状態を解除する． つまり，何か選択されたコマがあれば，どこをクリックしても選択状態が解除される．

Boardクラスにselectメソッドが無い問題の修正